### PR TITLE
Add engineering upgrade docs and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,13 @@ This project is a **tech demo,** a **joke,** and a **completely unnecessary use 
 > **Built with way too much effort for a simple TODO app.**  
 
 Enjoy! 🎩
+
+---
+
+### 📚 Engineering Upgrade Docs
+For the execution-focused roadmap and contributor/agent guidance, see:
+- `docs/upgrade-phases.md`
+- `docs/architecture.md`
+- `docs/slo.md`
+- `docs/agent-execution-playbook.md`
+- `docs/runbooks/game-day.md`

--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ Enjoy! 🎩
 ### 📚 Engineering Upgrade Docs
 For the execution-focused roadmap and contributor/agent guidance, see:
 - `docs/upgrade-phases.md`
+- `docs/phase-0-execution.md`
 - `docs/architecture.md`
 - `docs/slo.md`
+- `docs/reports/phase0-baseline-template.md`
 - `docs/agent-execution-playbook.md`
 - `docs/runbooks/game-day.md`
+- `scripts/phase0_baseline.py`

--- a/docs/agent-execution-playbook.md
+++ b/docs/agent-execution-playbook.md
@@ -7,6 +7,7 @@ This playbook helps human contributors and coding agents execute upgrades consis
 2. Keep pull requests small and reversible.
 3. Add/adjust observability whenever behavior changes.
 4. Prefer contract-first changes for any API modification.
+5. Before starting Phase 1+, ensure Phase 0 checklist is complete in `docs/phase-0-execution.md`.
 
 ## PR Checklist
 - [ ] Scope linked to one phase (`docs/upgrade-phases.md`)

--- a/docs/agent-execution-playbook.md
+++ b/docs/agent-execution-playbook.md
@@ -1,0 +1,45 @@
+# Agent Execution Playbook
+
+This playbook helps human contributors and coding agents execute upgrades consistently.
+
+## Execution Rules
+1. Work in one phase at a time.
+2. Keep pull requests small and reversible.
+3. Add/adjust observability whenever behavior changes.
+4. Prefer contract-first changes for any API modification.
+
+## PR Checklist
+- [ ] Scope linked to one phase (`docs/upgrade-phases.md`)
+- [ ] Docs updated (architecture/SLO/runbook if applicable)
+- [ ] Tests/checks run and captured in PR
+- [ ] Rollback notes included
+- [ ] No unrelated refactors
+
+## Branching Convention
+- `phase-<n>/<short-topic>`
+Examples:
+- `phase-1/openapi-contract`
+- `phase-2/otel-tracing`
+
+## Commit Message Convention
+`[P<n>] <area>: <summary>`
+
+Examples:
+- `[P1] contract: add todo v1 OpenAPI schema`
+- `[P3] data: enforce optimistic concurrency on PUT`
+
+## Task Slicing Heuristic
+A task is correctly sized if it can be:
+- reviewed in under 20 minutes,
+- rolled back with one revert commit,
+- validated with one clear acceptance check.
+
+## Risk Tiers
+- **Low**: docs, tests, non-runtime behavior
+- **Medium**: endpoint handlers, schema-compatible changes
+- **High**: DB migrations, gateway routing, auth, reliability policies
+
+High-risk changes must include:
+- explicit rollback steps,
+- before/after metrics plan,
+- at least one failure-mode test.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,41 @@
+# Architecture Overview
+
+## Current Topology
+- Frontend (`todo-frontend`) calls `http://localhost/todo`
+- NGINX gateway routes by HTTP method:
+  - `POST` -> create-service (Haskell)
+  - `GET` -> read-service (Go)
+  - `PUT` -> update-service (Rust)
+  - `DELETE` -> delete-service (Erlang)
+- All services connect to MariaDB
+
+## Current Strengths
+- Clean service boundaries by operation
+- Polyglot implementation proving interoperability
+- Local-first deployment with Docker Compose
+- Kubernetes path already started for ingress/monitoring
+
+## Target Architecture (After Upgrades)
+1. **Contract Layer**
+   - OpenAPI as source of truth
+   - Generated clients and compatibility checks
+2. **Telemetry Layer**
+   - OTel traces, structured logs, RED metrics
+3. **Correctness Layer**
+   - Idempotency and optimistic concurrency
+4. **Eventing Layer**
+   - Outbox events + asynchronous projection
+5. **Delivery Layer**
+   - Canary rollout + rollback automation
+
+## Request Flows
+### Read Flow
+Frontend -> Gateway -> Read Service -> DB -> Frontend
+
+### Write Flow (Target)
+Frontend -> Gateway -> CRUD Service -> DB transaction (state + outbox) -> Event dispatcher -> Projections
+
+## Invariants
+- API compatibility is checked before merge.
+- Every production issue must be traceable with a request/trace id.
+- Writes are safe under retries and concurrent edits.

--- a/docs/phase-0-execution.md
+++ b/docs/phase-0-execution.md
@@ -1,0 +1,48 @@
+# Phase 0 Execution Record
+
+This document is the single source of truth for planning and completing Phase 0.
+
+## Goal
+Establish baseline architecture understanding, reliability targets, and measurable endpoint performance before introducing higher-order system complexity.
+
+## Work Plan
+1. Document current architecture and core invariants.
+2. Define initial SLI/SLO targets and error budget policy.
+3. Capture repeatable baseline metrics for `/todo` read path.
+4. Create a standardized report template for future comparisons.
+
+## Execution Checklist
+- [x] Architecture snapshot and invariants documented (`docs/architecture.md`).
+- [x] Initial SLO policy documented (`docs/slo.md`).
+- [x] Baseline capture script added (`scripts/phase0_baseline.py`).
+- [x] Baseline report template added (`docs/reports/phase0-baseline-template.md`).
+- [x] Baseline run executed and raw JSON committed (`docs/reports/phase0-baseline.json`).
+- [ ] Baseline run executed against a healthy live stack (current run was against an unavailable local gateway).
+- [ ] Baseline markdown report committed as `docs/reports/phase0-baseline-YYYY-MM-DD.md`.
+
+## Executed Command (2026-03-25 UTC)
+```sh
+python3 scripts/phase0_baseline.py --base-url http://localhost --requests 5 --timeout 1 --output docs/reports/phase0-baseline.json
+```
+
+## Current Findings
+- Local gateway was unreachable during measurement (`connection refused`).
+- This run validates tooling and report generation, not service performance.
+- Next run should be performed after `docker-compose up --build -d`.
+
+## How To Execute Healthy Baseline Run
+1. Start stack:
+   ```sh
+   cp .env-example .env
+   docker-compose up --build -d
+   ```
+2. Run probe:
+   ```sh
+   python3 scripts/phase0_baseline.py --base-url http://localhost --requests 30 --output docs/reports/phase0-baseline.json
+   ```
+3. Copy numbers into report template and commit both JSON + Markdown report.
+
+## Exit Criteria (Phase 0)
+- A new contributor can explain end-to-end read flow in under 2 minutes.
+- SLO target values exist with a stated review cadence.
+- Baseline report exists and can be regenerated from one command.

--- a/docs/reports/phase0-baseline-template.md
+++ b/docs/reports/phase0-baseline-template.md
@@ -1,0 +1,28 @@
+# Phase 0 Baseline Report
+
+- Date (UTC): `YYYY-MM-DD`
+- Environment: `local docker-compose | minikube | other`
+- Git commit: `<sha>`
+- Command:
+  ```sh
+  python3 scripts/phase0_baseline.py --base-url http://localhost --requests 30 --output docs/reports/phase0-baseline.json
+  ```
+
+## Summary
+- GET availability: `xx.xxx%`
+- GET p95 latency: `xxx ms`
+- GET p99 latency: `xxx ms`
+- SLO pass/fail: `PASS | FAIL`
+
+## Raw Output
+Attach or reference:
+- `docs/reports/phase0-baseline.json`
+
+## Observations
+- Example: warm-up effects observed in first 3 requests.
+- Example: failures tied to gateway startup race.
+
+## Follow-Ups
+- [ ] Tune timeout values
+- [ ] Add write-path controlled benchmark fixture
+- [ ] Compare against previous run and document trend

--- a/docs/reports/phase0-baseline.json
+++ b/docs/reports/phase0-baseline.json
@@ -1,0 +1,46 @@
+{
+  "captured_at_utc": "2026-03-25T14:18:09.969757+00:00",
+  "base_url": "http://localhost",
+  "target": "http://localhost/todo",
+  "probes": {
+    "GET /todo": {
+      "requests": 5,
+      "successes": 0,
+      "failures": 5,
+      "availability": 0.0,
+      "latency_ms": {
+        "min": 0.414,
+        "avg": 2.194,
+        "p95": 8.809,
+        "p99": 8.809,
+        "max": 8.809
+      },
+      "failure_samples": [
+        {
+          "status": null,
+          "error": "<urlopen error [Errno 111] Connection refused>"
+        },
+        {
+          "status": null,
+          "error": "<urlopen error [Errno 111] Connection refused>"
+        },
+        {
+          "status": null,
+          "error": "<urlopen error [Errno 111] Connection refused>"
+        },
+        {
+          "status": null,
+          "error": "<urlopen error [Errno 111] Connection refused>"
+        },
+        {
+          "status": null,
+          "error": "<urlopen error [Errno 111] Connection refused>"
+        }
+      ]
+    }
+  },
+  "notes": [
+    "POST/PUT/DELETE baseline is intentionally excluded in Phase 0 to avoid mutating state during smoke runs.",
+    "Add write-path probes in a controlled fixture environment before Phase 3."
+  ]
+}

--- a/docs/runbooks/game-day.md
+++ b/docs/runbooks/game-day.md
@@ -1,0 +1,47 @@
+# Game Day Runbook (Reliability Drills)
+
+Run these drills after Phase 2 observability is in place.
+
+## Objective
+Validate the system's behavior during common failure modes and verify alerts/SLO indicators are meaningful.
+
+## Prerequisites
+- Stack running locally or in cluster
+- Metrics dashboard available
+- Trace visibility enabled
+
+## Drill 1 — Read service outage
+### Inject
+- Stop/read-service instance or scale to zero.
+
+### Expected
+- `GET /todo` fails predictably.
+- Errors are visible in dashboard and logs.
+- Other operations remain unaffected as much as possible.
+
+### Validate
+- Error rate spikes are captured.
+- Trace spans show failure boundary.
+- Recovery time is recorded after service restoration.
+
+## Drill 2 — DB latency injection
+### Inject
+- Add artificial delay in DB path or network latency.
+
+### Expected
+- Latency SLO degradation appears on p95 charts.
+- Timeouts trigger as configured.
+- Retries do not overwhelm dependent services.
+
+### Validate
+- Clear latency trend in metrics.
+- No runaway retry storm.
+- Error budget impact is measurable.
+
+## Post-Drill Review Template
+- Scenario:
+- Start/stop times:
+- SLO impact:
+- Alerts fired (yes/no):
+- Unexpected behavior:
+- Action items:

--- a/docs/slo.md
+++ b/docs/slo.md
@@ -1,0 +1,35 @@
+# Service Level Objectives (Initial)
+
+These SLOs are intentionally simple and can tighten over time.
+
+## SLI Definitions
+- **Availability SLI**: successful HTTP responses / total requests
+- **Latency SLI**: request duration distribution per endpoint
+- **Correctness SLI**: percentage of write requests that preserve idempotency and concurrency guarantees
+
+## SLO Targets (v1)
+- `GET /todo`
+  - Availability: 99.5%
+  - p95 latency: < 250ms
+- `POST|PUT|DELETE /todo*`
+  - Availability: 99.0%
+  - p95 latency: < 400ms
+
+## Error Budget
+- Monthly availability budget for 99.5%: ~3h 39m downtime
+- Monthly availability budget for 99.0%: ~7h 18m downtime
+
+## Alerting Strategy (Planned)
+- Fast burn: 2% budget in 1 hour
+- Slow burn: 5% budget in 6 hours
+
+## Measurement Plan
+- Metrics source: service instrumentation + gateway metrics
+- Dashboards: per endpoint RED + error classes
+- Review cadence: weekly reliability review
+
+## Change Policy
+Any change that can materially affect latency or error rates must include:
+1. Expected SLO impact
+2. Rollback strategy
+3. Observability updates

--- a/docs/upgrade-phases.md
+++ b/docs/upgrade-phases.md
@@ -23,13 +23,21 @@ If a task does not improve one of the above, defer it.
 ## Phase 0 — Baseline + Guardrails (1–2 days)
 
 ### Deliverables
-- `docs/architecture.md`: current topology + request flows
-- `docs/slo.md`: first SLOs and measurements
-- Baseline latency/error measurements for CRUD endpoints
+- `docs/architecture.md`: current topology + request flows + invariants
+- `docs/slo.md`: first SLO policy and error-budget posture
+- `scripts/phase0_baseline.py`: reproducible latency/availability probe
+- `docs/reports/phase0-baseline-template.md`: report format for comparable snapshots
+- `docs/phase-0-execution.md`: execution checklist and status
+
+### Execution Command
+```sh
+python3 scripts/phase0_baseline.py --base-url http://localhost --requests 30 --output docs/reports/phase0-baseline.json
+```
 
 ### Exit Criteria
 - A new contributor can explain request flow end-to-end in under 2 minutes.
 - SLOs are measurable with existing telemetry or local scripts.
+- A baseline report exists and is reproducible from one command.
 
 ---
 

--- a/docs/upgrade-phases.md
+++ b/docs/upgrade-phases.md
@@ -1,0 +1,114 @@
+# Overkill(ed) Todo App — Upgrade Phases
+
+This document turns the roadmap into an execution plan that humans and agents can run incrementally.
+
+## North Star
+Build a **small app with big-system qualities**:
+- Contract stability
+- Deep observability
+- Data correctness under concurrency
+- Resilience under failure
+
+## Scope Guardrails (No Bloat)
+Only add work that creates one of these outcomes:
+1. Better correctness
+2. Better operability
+3. Better reliability
+4. Better security
+
+If a task does not improve one of the above, defer it.
+
+---
+
+## Phase 0 — Baseline + Guardrails (1–2 days)
+
+### Deliverables
+- `docs/architecture.md`: current topology + request flows
+- `docs/slo.md`: first SLOs and measurements
+- Baseline latency/error measurements for CRUD endpoints
+
+### Exit Criteria
+- A new contributor can explain request flow end-to-end in under 2 minutes.
+- SLOs are measurable with existing telemetry or local scripts.
+
+---
+
+## Phase 1 — Contract-First API (3–5 days)
+
+### Deliverables
+- `api/openapi/todo.v1.yaml`
+- Generated TypeScript client under `todo-frontend/src/api/generated/`
+- CI job for API lint + breaking-change detection
+
+### Exit Criteria
+- Frontend API calls use generated client.
+- Contract checks fail CI on breaking changes.
+
+---
+
+## Phase 2 — End-to-End Observability (4–6 days)
+
+### Deliverables
+- Trace propagation from frontend -> gateway -> service -> DB
+- Structured logs with trace IDs
+- RED metrics dashboard (rate, errors, duration)
+
+### Exit Criteria
+- One user action is visible as one trace chain across services.
+- p95 endpoint latency visible per service.
+
+---
+
+## Phase 3 — Correctness Semantics (4–7 days)
+
+### Deliverables
+- DB migration adding optimistic concurrency metadata (`version`)
+- `PUT /todo/{id}` concurrency checks with conflict response
+- Idempotency key support for `POST /todo`
+
+### Exit Criteria
+- Concurrent write conflict returns deterministic 409 behavior.
+- Duplicate POST retries do not create duplicate records.
+
+---
+
+## Phase 4 — Outbox + Eventing (5–8 days)
+
+### Deliverables
+- Outbox schema migration
+- Transactional write + outbox insert
+- Dispatcher and replayable projector
+
+### Exit Criteria
+- No lost events between DB commit and publish.
+- Read model can be rebuilt by replaying events.
+
+---
+
+## Phase 5 — Reliability + Progressive Delivery (3–5 days)
+
+### Deliverables
+- Timeout/retry/circuit policies
+- Canary release for one service
+- Two game-day scenarios documented and executed
+
+### Exit Criteria
+- Canary can auto-rollback on SLO breach.
+- Failure drills are reproducible with runbook steps.
+
+---
+
+## Suggested Ticket Naming
+Use this format to keep work searchable:
+`[P{phase}] {area}: {outcome}`
+
+Examples:
+- `[P1] contract: add OpenAPI schema for todo v1`
+- `[P2] telemetry: propagate traceparent through gateway`
+- `[P3] data: enforce optimistic concurrency on update`
+
+## Definition of Done (All Phases)
+- Docs updated
+- Tests/checks pass locally
+- Observability added for new critical paths
+- Rollback plan documented for risky changes

--- a/scripts/phase0_baseline.py
+++ b/scripts/phase0_baseline.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Capture Phase 0 baseline latency and availability for /todo endpoints.
+
+Usage examples:
+  python3 scripts/phase0_baseline.py --base-url http://localhost --output docs/reports/phase0-baseline.json
+  python3 scripts/phase0_baseline.py --base-url http://localhost --requests 30 --timeout 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+
+def run_probe(method: str, url: str, timeout: float, payload: bytes | None = None) -> tuple[bool, int | None, float, str | None]:
+    req = urllib.request.Request(url=url, method=method)
+    if payload is not None:
+        req.add_header("Content-Type", "application/json")
+
+    started = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, data=payload, timeout=timeout) as resp:
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            return True, resp.status, elapsed_ms, None
+    except urllib.error.HTTPError as exc:
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        return False, exc.code, elapsed_ms, str(exc)
+    except Exception as exc:  # noqa: BLE001 - baseline tool should capture all failures.
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        return False, None, elapsed_ms, str(exc)
+
+
+def percentile(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = int(round((p / 100) * (len(ordered) - 1)))
+    return ordered[idx]
+
+
+def summarize(results: list[tuple[bool, int | None, float, str | None]]) -> dict:
+    latencies = [r[2] for r in results]
+    successes = [r for r in results if r[0]]
+    failures = [r for r in results if not r[0]]
+
+    return {
+        "requests": len(results),
+        "successes": len(successes),
+        "failures": len(failures),
+        "availability": round((len(successes) / len(results)) * 100, 3) if results else 0.0,
+        "latency_ms": {
+            "min": round(min(latencies), 3) if latencies else 0.0,
+            "avg": round(statistics.fmean(latencies), 3) if latencies else 0.0,
+            "p95": round(percentile(latencies, 95), 3),
+            "p99": round(percentile(latencies, 99), 3),
+            "max": round(max(latencies), 3) if latencies else 0.0,
+        },
+        "failure_samples": [
+            {"status": status, "error": err} for _, status, _, err in failures[:5]
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Phase 0 /todo baseline probe")
+    parser.add_argument("--base-url", default="http://localhost", help="Gateway base URL")
+    parser.add_argument("--requests", type=int, default=25, help="Requests per probe")
+    parser.add_argument("--timeout", type=float, default=2.0, help="Per-request timeout seconds")
+    parser.add_argument("--output", default="docs/reports/phase0-baseline.json", help="Output JSON file path")
+    args = parser.parse_args()
+
+    target = f"{args.base_url.rstrip('/')}/todo"
+
+    get_results = [run_probe("GET", target, args.timeout) for _ in range(args.requests)]
+
+    now = datetime.now(timezone.utc).isoformat()
+    report = {
+        "captured_at_utc": now,
+        "base_url": args.base_url,
+        "target": target,
+        "probes": {
+            "GET /todo": summarize(get_results),
+        },
+        "notes": [
+            "POST/PUT/DELETE baseline is intentionally excluded in Phase 0 to avoid mutating state during smoke runs.",
+            "Add write-path probes in a controlled fixture environment before Phase 3.",
+        ],
+    }
+
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2)
+        handle.write("\n")
+
+    print(json.dumps(report, indent=2))
+    print(f"\nWrote baseline report to: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide an execution-focused roadmap, runbooks, SLOs, and contributor/agent guidance to support phased upgrades and safer changes. 
- Make the new engineering guidance discoverable from the project `README.md` so contributors can follow conventions and risk guardrails.

### Description
- Add an "Engineering Upgrade Docs" section to `README.md` linking to the new documentation files. 
- Add `docs/upgrade-phases.md` with a phase-based roadmap, deliverables, and exit criteria for incremental upgrades. 
- Add `docs/architecture.md` describing current topology, request flows, and target architecture goals. 
- Add `docs/slo.md`, `docs/runbooks/game-day.md`, and `docs/agent-execution-playbook.md` with SLO definitions, game-day runbooks, and an execution/playbook checklist and conventions.

### Testing
- This is a documentation-only change, so no unit or integration tests were modified or required. 
- No automated tests were executed as part of this change. 
- Existing CI/test suites were not changed and are expected to behave the same as before.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3e6b8d508832c9afa4cb7570be958)